### PR TITLE
Adds support for Elastic Search and Kibana 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a docker container intended to run inside a Kubernetes cluster to collec
 
 This is so that you can automate deploying Kibana searches, visualizations, index-patterns, dashboards and watchers.
 
-The contained python script is working with the Kubernetes API `1.10` or later and Kibana API `6.4.x` or later
+The contained python script is working with the Kubernetes API `1.10` or later and Kibana API `6.4.x` or later `6.x` versions and Kibana `7.0` or later `7.x` versions
 
 # Why?
 
@@ -21,8 +21,8 @@ Run the container created by this repo in a single pod (as a `Deployment` with `
 
 # Prerequisites
 
-You must be using Kibana version `6.4.x` or later
-  - We use the `_bulk_create` API which was added in `6.4`
+You must be using Kibana version `6.4.x` or later `6.x` versions and Kibana `7.0` or later `7.x` versions
+  - We use the `_bulk_create` API which was added in `6.4` and Watcher APIs
 
 # Features
 


### PR DESCRIPTION
The bulk_update API has no incompatible changes for 6.x to 7.x HOWEVER, your kibana objects themselves will need to change.
See: https://www.elastic.co/guide/en/kibana/7.0/breaking-changes-7.0.html#breaking-changes-7.0-saved-objects

Detects which version of Elastic is being used and dynamically chooses the appropriate API endpoints for Watcher Alerts.
