### PR TITLE
Address HIGH and CRITICAL CVEs found during trivy Docker image scans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
-FROM python:3.6-slim-stretch
-RUN pip install kubernetes==10.0.0 logstash_formatter>=0.5.17
+FROM ubuntu:focal
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        python3 \
+        python3-pip \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir kubernetes==12.0.1 logstash_formatter>=0.5.17
 COPY sidecar/kibana-sidecar.py /app/
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app/
-CMD [ "python", "-u", "/app/kibana-sidecar.py" ]
+CMD [ "python3", "-u", "/app/kibana-sidecar.py" ]


### PR DESCRIPTION
* switching base image from `python:3.6-slim-stretch` to `ubuntu:focal` to address 74 HIGH+CRITICAL CVEs identified via `trivy` scans
* upgrade `kubernetes` Python client from `10.0.0` to `12.0.1` to address CRITICAL severity CVE-2020-1747
